### PR TITLE
Add WinGet CI, automated builds, and tag-based releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build (Release)
+        run: msbuild BetterClearTypeTuner.sln -p:Configuration=Release -p:Platform="Any CPU" -m -v:m
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BetterClearTypeTuner-Release
+          path: BetterClearTypeTuner/bin/Release/BetterClearTypeTuner.exe
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+# Push a version tag (e.g. 1.4.0.3 or v1.4.0.3) to build Release, zip the exe,
+# and publish a GitHub Release asset — no manual upload.
+# Existing tags in this repo omit the "v" prefix; both forms work.
+
+on:
+  push:
+    tags:
+      - "[0-9]*"
+      - "v[0-9]*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version from tag
+        id: ver
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $version = $tag -replace '^v', ''
+          if ($version -notmatch '^\d+(\.\d+){1,3}$') {
+            throw "Tag '$tag' does not look like a version (expected 1.2.3 or v1.2.3.4)."
+          }
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Stamp assembly version from tag
+        shell: pwsh
+        run: |
+          $v = "${{ steps.ver.outputs.version }}"
+          $path = "BetterClearTypeTuner/Properties/AssemblyInfo.cs"
+          $text = Get-Content -Raw $path
+          $text = $text -replace 'AssemblyVersion\("[^"]+"\)', "AssemblyVersion(`"$v`")"
+          $text = $text -replace 'AssemblyFileVersion\("[^"]+"\)', "AssemblyFileVersion(`"$v`")"
+          Set-Content -Path $path -Value $text -NoNewline
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build (Release)
+        run: msbuild BetterClearTypeTuner.sln -p:Configuration=Release -p:Platform="Any CPU" -m -v:m
+
+      - name: Package portable zip
+        shell: pwsh
+        run: |
+          $v = "${{ steps.ver.outputs.version }}"
+          $exe = "BetterClearTypeTuner/bin/Release/BetterClearTypeTuner.exe"
+          if (-not (Test-Path $exe)) { throw "Missing build output: $exe" }
+          $zip = "BetterClearTypeTuner.$v.zip"
+          Compress-Archive -Path $exe -DestinationPath $zip -Force
+          Get-Item $zip | Format-List Name, Length, FullName
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Better ClearType Tuner ${{ steps.ver.outputs.version }}
+          tag_name: ${{ steps.ver.outputs.tag }}
+          generate_release_notes: true
+          files: BetterClearTypeTuner.${{ steps.ver.outputs.version }}.zip
+          fail_on_unmatched_files: true

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,47 @@
+name: Publish to WinGet
+
+# Submits each stable GitHub Release to microsoft/winget-pkgs so users can
+# `winget install bp2008.BetterClearTypeTuner`.
+#
+# Prerequisites (one-time — see PR / docs link in README):
+# 1. Repository secret WINGET_TOKEN — classic PAT with public_repo scope.
+# 2. First package submission via `wingetcreate new` (or a hand PR). This
+#    workflow only updates an existing package after that bootstrap merges.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Existing release tag to publish (e.g. 1.4.0.2)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for WINGET_TOKEN
+        id: gate
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [ -n "$WINGET_TOKEN" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::WINGET_TOKEN not set — skipping winget submission"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Submit to winget-pkgs
+        if: steps.gate.outputs.ok == 'true'
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: bp2008.BetterClearTypeTuner
+          # Releases ship a portable zip (BetterClearTypeTuner.<version>.zip).
+          installers-regex: 'BetterClearTypeTuner\..+\.zip$'
+          release-tag: ${{ inputs.release-tag || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ After the first package lands in the [Windows Package Manager community reposito
 
 Download from the [Releases Section](https://github.com/bp2008/BetterClearTypeTuner/releases), extract, and run.
 
+## Releasing (maintainers)
+
+Builds and release zips are produced by GitHub Actions — you do **not** need to upload binaries by hand.
+
+1. Merge your changes to `master`.
+2. Create and push a **version tag** matching the release number (same style as existing tags: `1.4.0.2`, optional `v` prefix also works):
+
+```powershell
+git checkout master
+git pull
+git tag 1.4.0.3
+git push origin 1.4.0.3
+```
+
+3. The [Release](.github/workflows/release.yml) workflow builds a Release binary, stamps `AssemblyVersion` / `AssemblyFileVersion` from the tag, zips `BetterClearTypeTuner.exe` as `BetterClearTypeTuner.<version>.zip`, and publishes a GitHub Release with that asset attached.
+4. If `WINGET_TOKEN` is configured, [Publish to WinGet](.github/workflows/winget.yml) then opens an update PR to `winget-pkgs` for that release.
+
+Continuous integration: every push/PR to `master` runs [Build](.github/workflows/build.yml) so the solution stays green without cutting a release.
+
 ## Caveats
 
 As of Windows 10 1903, pages 3-5 of Windows' built-in ClearType tuner have no effect on text rendering.  Therefore, these settings were omitted from this program.  This program assigns sane default values to the affected registry keys so that if they begin working again in the future, ... they will at least have sane values.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ Quickly set font-smoothing settings in Windows 10 and know what you are getting,
 
 ![Main Application Screenshot](https://i.imgur.com/1dMqenI.png)
 
-## Usage
+## Install
+
+### winget (once published)
+
+```powershell
+winget install bp2008.BetterClearTypeTuner
+```
+
+After the first package lands in the [Windows Package Manager community repository](https://github.com/microsoft/winget-pkgs), each new GitHub Release can open an update PR automatically via [`.github/workflows/winget.yml`](.github/workflows/winget.yml) (requires a `WINGET_TOKEN` repository secret). Setup guide: [Winget registration](https://github.com/dev-centr/general-knowledge/blob/main/docs/modules/ROOT/pages/how-to/winget-registration.adoc) (also published at [docs.devcentr.org](https://docs.devcentr.org/general-knowledge/how-to/winget-registration.html) when the docs site is current).
+
+### Manual download
 
 Download from the [Releases Section](https://github.com/bp2008/BetterClearTypeTuner/releases), extract, and run.
 


### PR DESCRIPTION
## Summary
- **Build CI** (`.github/workflows/build.yml`): compiles Release on every push/PR to `master`.
- **Tag → GitHub Release** (`.github/workflows/release.yml`): push a version tag (e.g. `1.4.0.3` or `v1.4.0.3`) to build, stamp assembly version from the tag, zip `BetterClearTypeTuner.exe` as `BetterClearTypeTuner.<version>.zip`, and attach it to a new GitHub Release — no manual upload.
- **WinGet** (`.github/workflows/winget.yml`): after a Release is published, opens an update PR to `microsoft/winget-pkgs` for `bp2008.BetterClearTypeTuner` (once bootstrapped).
- README documents install + the tag-based release workflow.

## How releasing works (tags)
You no longer need to build locally and drag a zip onto the Releases UI.

```powershell
git checkout master
git pull
# ... merge your fix/feature ...
git tag 1.4.0.3
git push origin 1.4.0.3
```

GitHub Actions then:
1. Builds Release with MSBuild
2. Sets `AssemblyVersion` / `AssemblyFileVersion` from the tag
3. Publishes `BetterClearTypeTuner.1.4.0.3.zip` on the GitHub Release
4. (Optional) Submits the winget update if `WINGET_TOKEN` is set

Existing tags in this repo already use the `1.4.0.2` style (no `v`); both forms are accepted.

## One-time WinGet setup
Winget publish bots only **update** packages that already exist. Please do this once:

1. Create a **classic** GitHub PAT with the `public_repo` scope (fine-grained tokens do not work).
2. Add it as a repository secret named `WINGET_TOKEN` (Settings → Secrets and variables → Actions).
3. Bootstrap the first package (Windows):
   ```powershell
   winget install Microsoft.WingetCreate
   wingetcreate new https://github.com/bp2008/BetterClearTypeTuner/releases/download/1.4.0.2/BetterClearTypeTuner.1.4.0.2.zip
   ```
   Use package id `bp2008.BetterClearTypeTuner`. The zip contains `BetterClearTypeTuner.exe` at the root.
4. After that first `winget-pkgs` PR merges, later tags/releases are handled automatically.

Walkthrough: https://github.com/dev-centr/general-knowledge/blob/main/docs/modules/ROOT/pages/how-to/winget-registration.adoc

## Suggestion: GitHub About field
- Put `winget install bp2008.BetterClearTypeTuner` in the About **description**, and/or
- Set the About **Website** URL to: `https://github.com/bp2008/BetterClearTypeTuner#install`

## Test plan
- [ ] Open a PR / push to this branch and confirm **Build** runs green
- [ ] After merge, push a test tag (or wait for the next real version) and confirm **Release** creates the zip asset
- [ ] Confirm asset name matches prior convention: `BetterClearTypeTuner.<version>.zip` with exe at zip root
- [ ] After `WINGET_TOKEN` + first manual winget-pkgs PR, confirm **Publish to WinGet** opens an update PR