### PR TITLE
Fix Restore Defaults writing invalid ClearType contrast 0

### DIFF
--- a/BetterClearTypeTuner/MainForm.cs
+++ b/BetterClearTypeTuner/MainForm.cs
@@ -280,7 +280,7 @@ namespace BetterClearTypeTuner
 			setDefaults = true;
 			cbFontAntialiasing.Checked = true;
 			rbRGB.Checked = true;
-			nudContrast.Value = 0;
+			nudContrast.Value = FontSmoothing.ContrastDefault;
 			EnableEvents();
 			ControlsChanged(sender, e);
 		}

--- a/BetterClearTypeTuner/MainWindow.xaml.cs
+++ b/BetterClearTypeTuner/MainWindow.xaml.cs
@@ -94,7 +94,7 @@ namespace BetterClearTypeTuner
 			setDefaults = true;
 			cbEnableFontAntialiasing.IsChecked = true;
 			rbRGB.IsChecked = true;
-			txtContrast.Text = "0";
+			txtContrast.Text = FontSmoothing.ContrastDefault.ToString();
 			EnableEvents();
 			ControlsChanged();
 		}

--- a/BetterClearTypeTuner/Native/FontSmoothing.cs
+++ b/BetterClearTypeTuner/Native/FontSmoothing.cs
@@ -76,11 +76,24 @@ namespace BetterClearTypeTuner.Native
 			return contrast;
 		}
 		/// <summary>
+		/// Microsoft-documented valid range for ClearType contrast (SPI_SETFONTSMOOTHINGCONTRAST).
+		/// Values outside this range break Java AWT/Swing (IllegalArgumentException on KEY_TEXT_LCD_CONTRAST).
+		/// </summary>
+		public const uint ContrastMin = 1000;
+		public const uint ContrastMax = 2200;
+		public const uint ContrastDefault = 1400;
+
+		/// <summary>
 		/// Sets the font smoothing contrast.
+		/// Values are clamped to the documented 1000–2200 range.
 		/// </summary>
 		/// <returns></returns>
 		public static void SetContrast(uint contrast)
 		{
+			if (contrast < ContrastMin)
+				contrast = ContrastMin;
+			else if (contrast > ContrastMax)
+				contrast = ContrastMax;
 			User32.SystemParametersInfoW(SPI.SPI_SETFONTSMOOTHINGCONTRAST, 0, contrast, SPIF.SPIF_UPDATEINIFILE | SPIF.SPIF_SENDCHANGE);
 		}
 	}


### PR DESCRIPTION
## Summary
- Restore Defaults was setting ClearType contrast to `0`, which is outside Microsoft's documented 1000–2200 range and ends up in `FontSmoothingGamma`.
- That invalid value crashes Java AWT/Swing at startup (`IllegalArgumentException: 0 incompatible with Text-specific LCD contrast key`), matching #20.
- Restore Defaults now uses the documented default (1400), and `SetContrast` clamps SPI writes to 1000–2200.

## Test plan
- [ ] Run the app, set contrast to a mid-range value, then click Restore Defaults — contrast should become 1400 (not 0 / red).
- [ ] Manually enter a value below 1000 (e.g. 0) and apply — system contrast should clamp to 1000.
- [ ] After Restore Defaults, launch a Java Swing/AWT app (or OpenJDK `java` GUI) and confirm it starts without hanging or the LCD-contrast exception.
- [ ] Optionally confirm `HKCU\Control Panel\Desktop\FontSmoothingGamma` is in 1000–2200 after restore.

Fixes #20

Made with [Cursor](https://cursor.com)